### PR TITLE
Use #map instead of #each to check iterability

### DIFF
--- a/lib/jsonapi/serializable/resource_builder.rb
+++ b/lib/jsonapi/serializable/resource_builder.rb
@@ -18,7 +18,7 @@ module JSONAPI
         return objects if objects.nil? ||
                           Array(objects).first.respond_to?(:as_jsonapi)
 
-        if objects.respond_to?(:each)
+        if objects.respond_to?(:map)
           objects.map { |obj| new(obj, expose, klass).resource }
         else
           new(objects, expose, klass).resource


### PR DESCRIPTION
A popular alternative to ActiveRecord is Sequel. Sequel models respond
to #each - http://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/InstanceMethods.html#method-i-each

This means jsonapi-serializable incorrectly *thinks* we should be iterating over
something. It then calls #map and blows up, as Sequel::Model does not
implement #map.

This changes the check from #each to #map, since that's the method
actually being called.