### PR TITLE
Avoid creating throw-away ResourceBuilders + fix namespace inferrer + inference caching.

### DIFF
--- a/lib/jsonapi/serializable/relationship.rb
+++ b/lib/jsonapi/serializable/relationship.rb
@@ -9,6 +9,8 @@ module JSONAPI
       def initialize(exposures = {}, &block)
         exposures.each { |k, v| instance_variable_set("@#{k}", v) }
         @_exposures = exposures
+        @_exposures = { _resource_builder: ResourceBuilder.new }.merge!(@_exposures) unless @_exposures.key?(:_resource_builder)
+
         @_links     = {}
         instance_eval(&block)
       end

--- a/lib/jsonapi/serializable/relationship.rb
+++ b/lib/jsonapi/serializable/relationship.rb
@@ -9,7 +9,7 @@ module JSONAPI
       def initialize(exposures = {}, &block)
         exposures.each { |k, v| instance_variable_set("@#{k}", v) }
         @_exposures = exposures
-        @_exposures = { _resource_builder: ResourceBuilder.new }.merge!(@_exposures) unless @_exposures.key?(:_resource_builder)
+        @_exposures[:_resource_builder] ||= ResourceBuilder.new
 
         @_links     = {}
         instance_eval(&block)

--- a/lib/jsonapi/serializable/relationship/dsl.rb
+++ b/lib/jsonapi/serializable/relationship/dsl.rb
@@ -43,7 +43,7 @@ module JSONAPI
           # NOTE(beauby): Lazify computation since it is only needed when
           #   the corresponding relationship is included.
           @_resources_block = proc do
-            _resources_for(yield, resource_class)
+            @_resource_builder.build(yield, @_exposures, resource_class)
           end
         end
 
@@ -105,15 +105,6 @@ module JSONAPI
         #    end
         def link(name, &block)
           @_links[name] = Link.as_jsonapi(@_exposures, &block)
-        end
-
-        private
-
-        # @api private
-        def _resources_for(objects, resource_class)
-          resource_class ||= @_resource_inferrer
-
-          ResourceBuilder.build(objects, @_exposures, resource_class)
         end
       end
     end

--- a/lib/jsonapi/serializable/renderer.rb
+++ b/lib/jsonapi/serializable/renderer.rb
@@ -15,7 +15,8 @@ module JSONAPI
         @namespace  = @options.delete(:namespace)
         @inferrer   = @options.delete(:inferrer)
         @exposures  = @options.delete(:expose) || {}
-        @exposures[:_resource_inferrer] = namespace_inferrer || @inferrer
+        @exposures[:_resource_builder] = resource_builder
+        freeze
       end
 
       def render
@@ -24,6 +25,10 @@ module JSONAPI
 
       private
 
+      def resource_builder
+        ResourceBuilder.new(namespace_inferrer || @inferrer)
+      end
+
       # @api private
       def jsonapi_params
         @options
@@ -31,10 +36,7 @@ module JSONAPI
 
       # @api private
       def jsonapi_resources
-        toplevel_inferrer = @klass || @inferrer
-        JSONAPI::Serializable::ResourceBuilder.build(@objects,
-                                                     @exposures,
-                                                     toplevel_inferrer)
+        @exposures[:_resource_builder].build(@objects, @exposures, @klass)
       end
 
       # @api private

--- a/lib/jsonapi/serializable/resource.rb
+++ b/lib/jsonapi/serializable/resource.rb
@@ -21,7 +21,7 @@ module JSONAPI
       def initialize(exposures = {})
         exposures.each { |k, v| instance_variable_set("@#{k}", v) }
         @_exposures = exposures
-        @_exposures = { _resource_builder: ResourceBuilder.new }.merge!(@_exposures) unless @_exposures.key?(:_resource_builder)
+        @_exposures[:_resource_builder] ||= ResourceBuilder.new
       end
 
       def as_jsonapi(*)

--- a/lib/jsonapi/serializable/resource.rb
+++ b/lib/jsonapi/serializable/resource.rb
@@ -21,6 +21,7 @@ module JSONAPI
       def initialize(exposures = {})
         exposures.each { |k, v| instance_variable_set("@#{k}", v) }
         @_exposures = exposures
+        @_exposures = { _resource_builder: ResourceBuilder.new }.merge!(@_exposures) unless @_exposures.key?(:_resource_builder)
       end
 
       def as_jsonapi(*)

--- a/lib/jsonapi/serializable/resource_builder.rb
+++ b/lib/jsonapi/serializable/resource_builder.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   module Serializable
     class ResourceBuilder
-      DEFAULT_RESOURCE_INFERER = lambda do |object_klass_name|
+      DEFAULT_RESOURCE_INFERRER = lambda do |object_klass_name|
         names = object_klass_name.split('::'.freeze)
         klass_name = names.pop
         namespace = names.join('::'.freeze)
@@ -14,62 +14,49 @@ module JSONAPI
         Object.const_get(klass_name)
       end
 
-      def self.build(objects, expose, klass)
-        return objects if objects.nil? ||
-                          Array(objects).first.respond_to?(:as_jsonapi)
-
-        if objects.respond_to?(:each)
-          objects.map { |obj| new(obj, expose, klass).resource }
-        else
-          new(objects, expose, klass).resource
-        end
+      def initialize(inferrer = nil)
+        inferrer ||= DEFAULT_RESOURCE_INFERRER
+        define_singleton_method('infer_resource_class', &inferrer)
+        @_cache = {}
+        freeze
       end
 
-      attr_reader :resource
+      def build(objects, expose, klass)
+        return nil if objects.nil?
 
-      def initialize(object, expose, klass)
-        @object   = object
-        @expose   = expose || {}
-        @klass    = klass
-        @resource = serializable_class.new(serializable_params)
-        freeze
+        if objects.respond_to?(:to_ary)
+          Array(objects).map { |obj| serializable_resource(obj, expose, klass) }
+        else
+          serializable_resource(objects, expose, klass)
+        end
       end
 
       private
 
       # @api private
-      def serializable_params
-        @expose.merge(object: @object)
+      def serializable_resource(obj, expose, klass)
+        return obj if obj.respond_to?(:as_jsonapi)
+
+        serializable_class(obj, klass).new(expose.merge(object: obj))
       end
 
       # @api private
-      # rubocop:disable Metrics/MethodLength
-      def serializable_class
-        klass =
-          if @klass.respond_to?(:call)
-            @klass.call(@object.class.name)
-          elsif @klass.is_a?(Hash)
-            @klass[@object.class.name.to_sym]
-          elsif @klass.nil?
-            DEFAULT_RESOURCE_INFERER.call(@object.class.name)
-          else
-            @klass
+      def serializable_class(obj, klass)
+        klass_name = obj.class.name
+        @_cache[[klass_name, klass]] ||=
+          begin
+            if klass.nil?
+              klass = infer_resource_class(klass_name)
+            elsif klass.is_a?(Hash)
+              klass = klass[klass_name.to_sym]
+            end
+
+            if klass.is_a?(Class)
+              klass
+            else
+              Object.const_get(klass)
+            end
           end
-
-        reify_class(klass)
-      end
-      # rubocop:enable Metrics/MethodLength
-
-      # @api private
-      def reify_class(klass)
-        if klass.is_a?(Class)
-          klass
-        elsif klass.is_a?(String)
-          Object.const_get(klass)
-        else
-          # TODO(beauby): Raise meaningful exception.
-          raise
-        end
       end
     end
   end

--- a/spec/resource/relationship_inference_spec.rb
+++ b/spec/resource/relationship_inference_spec.rb
@@ -58,7 +58,8 @@ describe JSONAPI::Serializable::Resource, '.relationship' do
       relationship :posts
     end
     inferrer = proc { |_resource_class_name| SerializableBlog }
-    resource = klass.new(object: user, _resource_inferrer: inferrer)
+    resource_builder = JSONAPI::Serializable::ResourceBuilder.new(inferrer)
+    resource = klass.new(object: user, _resource_builder: resource_builder)
     actual = resource.jsonapi_related([:posts])[:posts]
 
     expect(actual.first.class).to eq(SerializableBlog)


### PR DESCRIPTION
Closes #18.