### PR TITLE
Allow specifying the type using a block

### DIFF
--- a/spec/resource/type_spec.rb
+++ b/spec/resource/type_spec.rb
@@ -19,6 +19,15 @@ describe JSONAPI::Serializable::Resource, '.type' do
     expect(resource.jsonapi_type).to eq(:foo)
   end
 
+  it 'accepts a block' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type { 'foo' }
+    end
+    resource = klass.new(object: User.new)
+
+    expect(resource.jsonapi_type).to eq(:foo)
+  end
+
   it 'defaults to :unknown' do
     klass = Class.new(JSONAPI::Serializable::Resource)
     resource = klass.new(object: User.new)


### PR DESCRIPTION
This PR adds the functionality to specify the type dynamically using a block.

See also issue #53 