### PR TITLE
Fix resource builder for Sequel.

### DIFF
--- a/lib/jsonapi/serializable/resource_builder.rb
+++ b/lib/jsonapi/serializable/resource_builder.rb
@@ -18,8 +18,8 @@ module JSONAPI
         return objects if objects.nil? ||
                           Array(objects).first.respond_to?(:as_jsonapi)
 
-        if objects.respond_to?(:each)
-          objects.map { |obj| new(obj, expose, klass).resource }
+        if objects.respond_to?(:to_ary)
+          Array(objects).map { |obj| new(obj, expose, klass).resource }
         else
           new(objects, expose, klass).resource
         end


### PR DESCRIPTION
 (check for collections via `respond_to?(:to_ary)` instead of `respond_to?(:each)`).
Fixes #57.