### PR TITLE
Add JSONAPI::Serializable::Error.create

### DIFF
--- a/lib/jsonapi/serializable/error.rb
+++ b/lib/jsonapi/serializable/error.rb
@@ -35,6 +35,12 @@ module JSONAPI
                       :link_blocks
       end
 
+      def self.create(hash)
+        hash.each_with_object(new) do |(k, v), e|
+          e.instance_variable_set("@_#{k}", v)
+        end
+      end
+
       self.link_blocks = {}
 
       def self.inherited(klass)

--- a/spec/error/create_spec.rb
+++ b/spec/error/create_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe JSONAPI::Serializable::Error, '.create' do
+  it 'ignores unknown members' do
+    hash = { unknown: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq({})
+  end
+
+  it 'supports id' do
+    hash = { id: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports status' do
+    hash = { status: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports code' do
+    hash = { code: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports title' do
+    hash = { title: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports detail' do
+    hash = { detail: 'foo' }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports meta' do
+    hash = { meta: { foo: 'bar' } }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports links' do
+    hash = {
+      links: {
+        about: {
+          href: 'foo://bar',
+          meta: { foo: 'bar' }
+        }
+      }
+    }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports source' do
+    hash = {
+      source: {
+        pointer: 'foo',
+        parameter: 'bar'
+      }
+    }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+
+  it 'supports combinations of members' do
+    hash = {
+      status: '422',
+      title: 'Invalid foo bar',
+      source: {
+        pointer: 'foo',
+        parameter: 'bar'
+      }
+    }
+
+    error = JSONAPI::Serializable::Error.create(hash)
+    expect(error.as_jsonapi).to eq(hash)
+  end
+end


### PR DESCRIPTION
This PR introduces a factory method for creating serializable errors, e.g.

```ruby
JSONAPI::Serializable::Error.create({
  status: "422",
  detail: "Invalid attribute"
  source: { pointer: "/data/attributes/title" }
})
```
