### PR TITLE
[WIP]: Use `extend` instead of `prepend` to add extensions to resource classes

### DIFF
--- a/spec/resource/key_format_spec.rb
+++ b/spec/resource/key_format_spec.rb
@@ -20,7 +20,7 @@ describe JSONAPI::Serializable::Resource do
 
     before do
       klass.class_eval do
-        prepend JSONAPI::Serializable::Resource::KeyFormat
+        extend JSONAPI::Serializable::Resource::KeyFormat
         self.key_format = proc { |k| k.to_s.capitalize }
         attribute :name
         attribute :address
@@ -58,6 +58,14 @@ describe JSONAPI::Serializable::Resource do
       let(:resource) { subclass.new(object: object) }
 
       it { is_expected.to eq(expected) }
+    end
+  end
+
+  context 'when KeyFormat is prepended' do
+    it 'outputs a deprecation warning' do
+      expect do
+        klass.prepend JSONAPI::Serializable::Resource::KeyFormat
+      end.to output(/DERPRECATION WARNING/).to_stderr
     end
   end
 end

--- a/spec/resource/key_format_spec.rb
+++ b/spec/resource/key_format_spec.rb
@@ -63,9 +63,8 @@ describe JSONAPI::Serializable::Resource do
 
   context 'when KeyFormat is prepended' do
     it 'outputs a deprecation warning' do
-      expect do
-        klass.prepend JSONAPI::Serializable::Resource::KeyFormat
-      end.to output(/DERPRECATION WARNING/).to_stderr
+      expect { klass.prepend JSONAPI::Serializable::Resource::KeyFormat }
+        .to output(/DERPRECATION WARNING/).to_stderr
     end
   end
 end


### PR DESCRIPTION
Fallback to `extend` when using `prepend` and generate a deprecation warning.

Blocked by #67 