### PR TITLE
Make inferrer a hash instead of a lambda.

### DIFF
--- a/lib/jsonapi/serializable/renderer.rb
+++ b/lib/jsonapi/serializable/renderer.rb
@@ -58,10 +58,12 @@ module JSONAPI
 
       # @api private
       def namespace_inferrer(namespace)
-        proc do |class_name|
-          names = class_name.split('::')
+        Hash.new do |h, k|
+          names = k.to_s.split('::')
           klass = names.pop
-          [namespace, *names, "Serializable#{klass}"].reject(&:nil?).join('::')
+          h[k] = [namespace, *names, "Serializable#{klass}"]
+                   .reject(&:nil?)
+                   .join('::')
         end
       end
     end

--- a/lib/jsonapi/serializable/renderer.rb
+++ b/lib/jsonapi/serializable/renderer.rb
@@ -11,13 +11,13 @@ module JSONAPI
       # Serialize resources into a JSON API document.
       #
       # @param resources [nil,Object,Array]
-      # @param options [Hash]@see JSONAPI.render
+      # @param options [Hash] @see JSONAPI.render
       # @option class [Class,Symbol,String,Hash{Symbol,String=>Class,Symbol,String}]
       #   The serializable resource class(es) to use for the primary resources.
       # @option namespace [String] The namespace in which to look for
       #   serializable resource classes.
-      # @option inferrer [#call] The callable used for inferring a serializable
-      #   resource class name from a resource class name.
+      # @option inferrer [Hash{Symbol=>String}] A map specifying for each type
+      #   the corresponding serializable resource class name.
       # @option expose [Hash] The exposures made available in serializable
       #   resource class instances as instance variables.
       # @return [Hash]

--- a/lib/jsonapi/serializable/resource_builder.rb
+++ b/lib/jsonapi/serializable/resource_builder.rb
@@ -25,7 +25,7 @@ module JSONAPI
 
       # @api private
       def _build(object, expose, klass)
-        serializable_class(object.class.name, klass)
+        serializable_class(object.class.name, klass || @inferrer)
           .new(expose.merge(object: object))
       end
 
@@ -33,8 +33,7 @@ module JSONAPI
       def serializable_class(object_class_name, klass)
         klass = klass[object_class_name.to_sym] if klass.is_a?(Hash)
 
-        @lookup_cache[[object_class_name, klass.to_s]] ||=
-          reify_class(klass || @inferrer.call(object_class_name))
+        @lookup_cache[[object_class_name, klass.to_s]] ||= reify_class(klass)
       end
 
       # @api private

--- a/spec/renderer/success_spec.rb
+++ b/spec/renderer/success_spec.rb
@@ -29,4 +29,38 @@ describe JSONAPI::Serializable::SuccessRenderer, '#render' do
     expect(hash[:data][:type]).to eq(:api_users)
     expect(hash[:included][0][:type]).to eq(:api_posts)
   end
+
+  context 'when providing a custom explicit inferrer' do
+    it 'uses the inferred serializable classes' do
+      inferrer = {
+        User: 'API::SerializableUser',
+        Post: 'API::SerializablePost'
+      }
+      hash = subject.render(user, include: [:posts], inferrer: inferrer)
+
+      expect(hash[:data][:type]).to eq(:api_users)
+      expect(hash[:included][0][:type]).to eq(:api_posts)
+    end
+  end
+
+  context 'when providing a custom implicit inferrer' do
+    it 'uses the inferred serializable classes' do
+      inferrer = Hash.new { |h, k| h[k] = "API::Serializable#{k}" }
+      hash = subject.render(user, include: [:posts], inferrer: inferrer)
+
+      expect(hash[:data][:type]).to eq(:api_users)
+      expect(hash[:included][0][:type]).to eq(:api_posts)
+    end
+  end
+
+  context 'when providing a custom inferrer and a namespace' do
+    it 'uses the inferred serializable classes' do
+      inferrer = Hash.new { |h, k| h[k] = "Serializable#{k}" }
+      hash = subject.render(user, include: [:posts],
+                            inferrer: inferrer, namespace: 'API')
+
+      expect(hash[:data][:type]).to eq(:api_users)
+      expect(hash[:included][0][:type]).to eq(:api_posts)
+    end
+  end
 end

--- a/spec/resource/relationship_inference_spec.rb
+++ b/spec/resource/relationship_inference_spec.rb
@@ -57,7 +57,7 @@ describe JSONAPI::Serializable::Resource, '.relationship' do
       type 'users'
       relationship :posts
     end
-    inferrer = proc { |_resource_class_name| SerializableBlog }
+    inferrer = Hash.new { |_resource_class_name| SerializableBlog }
     resource_builder = JSONAPI::Serializable::ResourceBuilder.new(inferrer)
     resource = klass.new(object: user, _resource_builder: resource_builder)
     actual = resource.jsonapi_related([:posts])[:posts]


### PR DESCRIPTION
This allows to customize the serializer lookup either explicitly:
```ruby
inferrer = {
  Post: MySerializablePost,
  User: MySerializableUser
}
```

or implicitly:
```ruby
inferrer = Hash.new do |h, k|
  h[k] = "MySerializable#{k}"
end
```

to provide to the renderer:
```ruby
renderer = JSONAPI::Serializable::SuccessRenderer.new
renderer.render(user, include: [:posts], inferrer: inferrer)
# => { ... }
```

Closes #74.