### PR TITLE
Forward method calls to parent resource when method missing in relationship

### DIFF
--- a/lib/jsonapi/serializable/relationship.rb
+++ b/lib/jsonapi/serializable/relationship.rb
@@ -45,6 +45,18 @@ module JSONAPI
 
         resources.respond_to?(:each) ? linkage_data : linkage_data.first
       end
+
+      def respond_to_missing?(m, include_private = false)
+        @_options[:_resource].respond_to?(m) || super
+      end
+
+      def method_missing(m, *args, &block)
+        if @_options[:_resource].respond_to?(m, true)
+          @_options[:_resource].send(m, *args, &block)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/jsonapi/serializable/resource.rb
+++ b/lib/jsonapi/serializable/resource.rb
@@ -28,6 +28,7 @@ module JSONAPI
         @_relationships = self.class.relationship_blocks
                               .each_with_object({}) do |(k, v), h|
           opts = self.class.relationship_options[k] || {}
+          opts = opts.merge(_resource: self)
           h[k] = Relationship.new(@_exposures, opts, &v)
         end
         @_meta = if (b = self.class.meta_block)


### PR DESCRIPTION
Fixes #51.