### PR TITLE
Remove warning about not initialized variable

### DIFF
--- a/lib/jsonapi/serializable/error.rb
+++ b/lib/jsonapi/serializable/error.rb
@@ -65,7 +65,7 @@ module JSONAPI
       end
 
       def source
-        return @_source if @_source
+        return @_source if defined?(@_source) && @_source
         return if self.class.source_block.nil?
         @_source = ErrorSource.as_jsonapi(@_exposures,
                                           &self.class.source_block)


### PR DESCRIPTION
Hey @beauby,
This PR removes: `warning: instance variable @_source not initialized`