### PR TITLE
[add lazy meta] Add the ability to run the meta in a lazy load

### DIFF
--- a/lib/jsonapi/serializable/relationship.rb
+++ b/lib/jsonapi/serializable/relationship.rb
@@ -15,12 +15,17 @@ module JSONAPI
       end
 
       def as_jsonapi(included)
+        @_included = included
         {}.tap do |hash|
           hash[:links] = @_links           if @_links.any?
           hash[:data]  = linkage_data      if included || @_include_linkage
-          hash[:meta]  = @_meta            unless @_meta.nil?
+          hash[:meta]  = meta_data         unless (@_meta_value.nil? && @_meta_block.nil?)
           hash[:meta]  = { included: false } if hash.empty?
         end
+      end
+
+      def included?
+        @_included
       end
 
       # @api private
@@ -44,6 +49,11 @@ module JSONAPI
         end
 
         resources.respond_to?(:each) ? linkage_data : linkage_data.first
+      end
+
+      # @api private
+      def meta_data
+        @_meta_value || @_meta_block&.call
       end
     end
   end

--- a/lib/jsonapi/serializable/relationship/dsl.rb
+++ b/lib/jsonapi/serializable/relationship/dsl.rb
@@ -52,8 +52,10 @@ module JSONAPI
         #     meta do
         #       { paginated: true }
         #     end
-        def meta(value = nil)
-          @_meta = value || yield
+        def meta(value = nil, &block)
+          @_meta_value = value
+          # NOTE: Lazify computation since it might make decisions based on included? or eager loading
+          @_meta_block = block unless value
         end
 
         # Declare a link for this relationship. The properties of the link are set

--- a/spec/renderer/relationship_spec.rb
+++ b/spec/renderer/relationship_spec.rb
@@ -32,4 +32,18 @@ describe JSONAPI::Serializable::Renderer, '#render_relationship' do
 
     expect(hash).to eq(expected)
   end
+
+  it 'can interigate included? in the meta block' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'users'
+
+      has_many(:posts) do
+        meta do
+          included?
+        end
+      end
+    end
+    expect_any_instance_of(JSONAPI::Serializable::Relationship).to receive(:included?)
+    subject.render(user, class: { User: klass, Post: SerializablePost })
+  end
 end


### PR DESCRIPTION
Let the user make decisions in the meta block that relate to the included nature of the relationships. 
If the relation is not loaded, then don't, for instance, include the count. 
It would also allow the user to take advantage of eager loading because Post.size would use the collection as opposed to a query. 