### PR TITLE
Do not restrict relationships via fieldsets

### DIFF
--- a/lib/jsonapi/serializable/resource.rb
+++ b/lib/jsonapi/serializable/resource.rb
@@ -45,8 +45,7 @@ module JSONAPI
         attrs = requested_attributes(fields).each_with_object({}) do |(k, v), h|
           h[k] = instance_eval(&v)
         end
-        rels = requested_relationships(fields)
-               .each_with_object({}) do |(k, v), h|
+        rels = requested_relationships.each_with_object({}) do |(k, v), h|
           h[k] = v.as_jsonapi(include.include?(k))
         end
         links = link_blocks.each_with_object({}) do |(k, v), h|
@@ -91,9 +90,10 @@ module JSONAPI
             .select { |k, _| fields.nil? || fields.include?(k) }
       end
 
+      # Note: overridden in conditional_fields.rb
       # @api private
-      def requested_relationships(fields)
-        @_relationships.select { |k, _| fields.nil? || fields.include?(k) }
+      def requested_relationships
+        @_relationships
       end
 
       # @api private

--- a/lib/jsonapi/serializable/resource/conditional_fields.rb
+++ b/lib/jsonapi/serializable/resource/conditional_fields.rb
@@ -98,7 +98,7 @@ module JSONAPI
         end
 
         # @api private
-        def requested_relationships(fields)
+        def requested_relationships
           super.select do |k, _|
             _conditionally_included?(self.class.field_condition_blocks, k)
           end

--- a/spec/resource/as_jsonapi_spec.rb
+++ b/spec/resource/as_jsonapi_spec.rb
@@ -45,21 +45,6 @@ describe JSONAPI::Serializable::Resource, '#as_jsonapi' do
     expect(actual).to eq(expected)
   end
 
-  it 'omits relationships member if none rendered' do
-    resource = SerializableUser.new(object: user)
-    actual = resource.as_jsonapi(fields: [:name, :address])
-    expected = {
-      type: :users,
-      id: 'foo',
-      attributes: {
-        name: 'Lucas',
-        address: '22 Ruby drive'
-      }
-    }
-
-    expect(actual).to eq(expected)
-  end
-
   it 'filters out fields' do
     resource = SerializableUser.new(object: user)
     actual = resource.as_jsonapi(fields: [:name])
@@ -68,7 +53,8 @@ describe JSONAPI::Serializable::Resource, '#as_jsonapi' do
       id: 'foo',
       attributes: {
         name: 'Lucas'
-      }
+      },
+      relationships: { posts: { meta: { included: false } } }
     }
 
     expect(actual).to eq(expected)


### PR DESCRIPTION
Imagine the URL:

```
/posts?fields[posts]=title&include=comments
```

Prior to this commit, the `included` payload would still render
comments, but there would be no `relationships` (at least not for
comments) in the primary data. The previous logic would omit the
relationship if a sparse fieldset was passed and the relationship name
was not in it.

This doesn't make logical sense - relationships are not fields, and the
request is clearly already asking for comments. In addition, rendering
`included` without a corresponding `relationship` is not valid JSONAPI.

This commit ensures we will render valid JSONAPI and not have to
duplicate `comments` in the fieldset.