### PR TITLE
Allow change of identifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'pry'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'pry'
 gemspec

--- a/lib/jsonapi/serializable/resource/dsl.rb
+++ b/lib/jsonapi/serializable/resource/dsl.rb
@@ -4,8 +4,8 @@ module JSONAPI
       module DSL
         def self.extended(klass)
           class << klass
-            attr_accessor :id_block, :type_val, :type_block, :attribute_blocks,
-                          :relationship_blocks, :relationship_options,
+            attr_accessor :id_name, :id_val, :id_block, :type_val, :type_block,
+                          :attribute_blocks, :relationship_blocks, :relationship_options,
                           :link_blocks, :meta_val, :meta_block
           end
 
@@ -17,6 +17,8 @@ module JSONAPI
 
         # rubocop:disable Metrics/AbcSize
         def inherited(klass)
+          klass.id_name    = id_name
+          klass.id_val     = id_val
           klass.id_block   = id_block
           klass.type_val   = type_val
           klass.type_block = type_block
@@ -29,13 +31,23 @@ module JSONAPI
         end
         # rubocop:enable Metrics/AbcSize
 
-        # Declare the JSON API id of this resource.
+        # @overload id(value)
+        #   Declare whether to show JSON API id of this resource.
+        #   @param [Boolean] value The flag whether to show id.
         #
-        # @yieldreturn [String] The id of the resource.
+        #   @example
+        #     id false
         #
-        # @example
-        #   id { @object.id.to_s }
-        def id(&block)
+        # @overload id(&block)
+        #   Declare the JSON API id of this resource
+        #
+        #   @yieldreturn [String] The id of the resource.
+        #
+        #   @example
+        #     id { @object.id.to_s }
+        def id(value = true, name: :id, &block)
+          self.id_val   = value
+          self.id_name  = name
           self.id_block = block
         end
 

--- a/spec/resource/id_spec.rb
+++ b/spec/resource/id_spec.rb
@@ -11,6 +11,29 @@ describe JSONAPI::Serializable::Resource, '.id' do
     expect(resource.jsonapi_id).to eq('foo')
   end
 
+  it 'accepts a boolean' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'foo'
+      id false
+    end
+
+    resource = klass.new(object: User.new)
+
+    expect(resource.as_jsonapi[:id]).to be_nil
+  end
+
+  it 'accepts new id name' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'foo'
+      id name: 'uuid'
+    end
+
+    user = User.new(uuid: 'foo')
+    resource = klass.new(object: user)
+
+    expect(resource.jsonapi_id).to eq('foo')
+  end
+
   it 'forwards to @object by default' do
     klass = Class.new(JSONAPI::Serializable::Resource) do
       type 'foo'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ class Model
 end
 
 class User < Model
-  attr_accessor :id, :name, :address, :posts
+  attr_accessor :id, :uuid, :name, :address, :posts
 end
 
 class Post < Model


### PR DESCRIPTION
This PR enables the dev to either change the name of identifier, by doing
```
class SerializableUser < SONAPI::Serializable::Resource
  id name: :uuid
end
```
or to not render ID at all:
```
class SerializableUser < SONAPI::Serializable::Resource
  id false
end
```
reasoning is: 
- not always there is need to display the id;
- sometimes models do not have id, and have uuid or some other id instead;

TODO:
- [ ] allow linking relationships based on new `id` name provided 

////
My first PR to open source, so please don't kill me all at once 😄 
Any suggestions are welcome!