### PR TITLE
Omit relationship meta when nil

### DIFF
--- a/lib/jsonapi/serializable/relationship.rb
+++ b/lib/jsonapi/serializable/relationship.rb
@@ -16,10 +16,11 @@ module JSONAPI
 
       def as_jsonapi(included)
         @_included = included
+        meta = meta_data unless (@_meta_value.nil? && @_meta_block.nil?)
         {}.tap do |hash|
-          hash[:links] = @_links           if @_links.any?
-          hash[:data]  = linkage_data      if included || @_include_linkage
-          hash[:meta]  = meta_data         unless (@_meta_value.nil? && @_meta_block.nil?)
+          hash[:links] = @_links             if @_links.any?
+          hash[:data]  = linkage_data        if included || @_include_linkage
+          hash[:meta]  = meta                unless meta.nil?
           hash[:meta]  = { included: false } if hash.empty?
         end
       end

--- a/spec/renderer/relationship_spec.rb
+++ b/spec/renderer/relationship_spec.rb
@@ -33,6 +33,77 @@ describe JSONAPI::Serializable::Renderer, '#render_relationship' do
     expect(hash).to eq(expected)
   end
 
+  it 'omits the meta key from a relationship document without meta' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'users'
+
+      has_many(:posts) do
+        link(:self) { "http://api.example.com/users/#{@object.id}/relationships/posts" }
+        link(:related) { "http://api.example.com/users/#{@object.id}/posts" }
+      end
+    end
+    hash = subject.render(user,
+                          relationship: :posts,
+                          class: { User: klass, Post: SerializablePost })
+    expected = {
+      data: [{ type: :posts, id: '1' }, { type: :posts, id: '2' }],
+      links: {
+        self: "http://api.example.com/users/foo/relationships/posts",
+        related: "http://api.example.com/users/foo/posts"
+      }
+    }
+
+    expect(hash).to eq(expected)
+  end
+
+  it 'omits the meta key from a relationship document when meta is nil' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'users'
+
+      has_many(:posts) do
+        link(:self) { "http://api.example.com/users/#{@object.id}/relationships/posts" }
+        link(:related) { "http://api.example.com/users/#{@object.id}/posts" }
+        meta nil
+      end
+    end
+    hash = subject.render(user,
+                          relationship: :posts,
+                          class: { User: klass, Post: SerializablePost })
+    expected = {
+      data: [{ type: :posts, id: '1' }, { type: :posts, id: '2' }],
+      links: {
+        self: "http://api.example.com/users/foo/relationships/posts",
+        related: "http://api.example.com/users/foo/posts"
+      }
+    }
+
+    expect(hash).to eq(expected)
+  end
+
+  it 'omits the meta key from a relationship document when meta block evaluates to nil' do
+    klass = Class.new(JSONAPI::Serializable::Resource) do
+      type 'users'
+
+      has_many(:posts) do
+        link(:self) { "http://api.example.com/users/#{@object.id}/relationships/posts" }
+        link(:related) { "http://api.example.com/users/#{@object.id}/posts" }
+        meta { nil }
+      end
+    end
+    hash = subject.render(user,
+                          relationship: :posts,
+                          class: { User: klass, Post: SerializablePost })
+    expected = {
+      data: [{ type: :posts, id: '1' }, { type: :posts, id: '2' }],
+      links: {
+        self: "http://api.example.com/users/foo/relationships/posts",
+        related: "http://api.example.com/users/foo/posts"
+      }
+    }
+
+    expect(hash).to eq(expected)
+  end
+
   it 'can interigate included? in the meta block' do
     klass = Class.new(JSONAPI::Serializable::Resource) do
       type 'users'


### PR DESCRIPTION
### Purpose

Omit relationship meta when `meta` is nil.

### Additional helpful information

This should match the behavior of nil meta rendering at other levels where meta may be used.