### PR TITLE
Conditional fields with key format

### DIFF
--- a/lib/jsonapi/serializable/resource/conditional_fields.rb
+++ b/lib/jsonapi/serializable/resource/conditional_fields.rb
@@ -46,6 +46,7 @@ module JSONAPI
         #
         def attribute(name, options = {}, &block)
           super
+          name = _format_key_for_condition(name)
           _register_condition(field_condition_blocks, name, options)
         end
 
@@ -57,6 +58,7 @@ module JSONAPI
         #
         def relationship(name, options = {}, &block)
           super
+          name = _format_key_for_condition(name)
           _register_condition(field_condition_blocks, name, options)
         end
 
@@ -86,6 +88,15 @@ module JSONAPI
             elsif options.key?(:unless)
               proc { !instance_exec(&options[:unless]) }
             end
+        end
+
+        def _format_key_for_condition(name)
+          ancestors = self.singleton_class.included_modules
+          if ancestors.include?(KeyFormat) && ancestors.index(KeyFormat) > ancestors.index(ConditionalFields)
+            _key_formatter.call(name)
+          else
+            name
+          end
         end
       end
 

--- a/spec/resource/conditional_fields_with_key_format_spec.rb
+++ b/spec/resource/conditional_fields_with_key_format_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+describe JSONAPI::Serializable::Resource do
+  let(:klass) do
+    Class.new(JSONAPI::Serializable::Resource) do
+      type 'foo'
+      id { 'bar' }
+    end
+  end
+
+  let(:object) { User.new }
+  let(:resource) do
+    klass.new(object: object, conditional: conditional)
+  end
+
+  context 'when the attribute is conditional and keys are formatted' do
+    before do
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::KeyFormat
+        key_format -> (k) { k.to_s.upcase }
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+      end
+    end
+
+    subject { resource.as_jsonapi[:attributes] }
+
+    context 'via :if' do
+      before do
+        klass.class_eval do
+          attribute :name, if: proc { @conditional } do
+            'foo'
+          end
+        end
+      end
+
+      context 'and the clause is true' do
+        let(:conditional) { true }
+
+        it { is_expected.to eq(NAME: 'foo') }
+      end
+
+      context 'and the clause is false' do
+        let(:conditional) { false }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context 'via :unless' do
+      before do
+        klass.class_eval do
+          attribute :name, unless: proc { @conditional } do
+            'foo'
+          end
+        end
+      end
+
+      context 'and the clause is true' do
+        let(:conditional) { true }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'and the clause is false' do
+        let(:conditional) { false }
+
+        it { is_expected.to eq(NAME: 'foo') }
+      end
+    end
+  end
+
+  context 'when relationship is conditional and keys are formatted' do
+    before do
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::KeyFormat
+        key_format -> (k) { k.to_s.upcase }
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
+        relationship :posts, if: -> { false }
+      end
+    end
+
+    subject { resource.as_jsonapi[:relationships] }
+
+    context 'and the clause is false' do
+      let(:conditional) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  context 'when a link is conditional and keys are formatted' do
+    before do
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::KeyFormat
+        key_format -> (k) { k.to_s.upcase }
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
+        link :self, if: proc { @conditional } do
+          'https://example.com/users/42'
+        end
+      end
+    end
+
+    subject { resource.as_jsonapi[:links] }
+
+    context 'and the clause is true' do
+      let(:conditional) { true }
+
+      it { is_expected.to eq(self: 'https://example.com/users/42') }
+    end
+
+    context 'and the clause is false' do
+      let(:conditional) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  context 'when inheriting and keys are formatted' do
+    before do
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::KeyFormat
+        key_format -> (k) { k.to_s.upcase }
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
+        relationship :posts, if: -> { false }
+      end
+    end
+
+    let(:subclass) { Class.new(klass) }
+    let(:resource) { subclass.new(object: object) }
+
+    subject { resource.as_jsonapi[:relationships] }
+
+    context 'and the clause is false' do
+      let(:conditional) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  context 'when a field and a link have the same name and keys are formatted' do
+    before do
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::KeyFormat
+        key_format -> (k) { k.to_s.upcase }
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+
+        attribute :name, if: proc { @conditional } do
+          'attribute'
+        end
+
+        link :name, unless: proc { @conditional } do
+          'link'
+        end
+      end
+    end
+
+    let(:conditional) { true }
+    subject { resource.as_jsonapi }
+
+    it "doesn't override previously registered condition" do
+      expect(subject[:attributes]).to eq(NAME: 'attribute')
+      expect(subject).not_to have_key(:links)
+    end
+  end
+end


### PR DESCRIPTION
Hey, I've noticed that when you use first KeyFormat and then ConditionalFields, some conditions are ignored. This happens when formatted key differs from the original key and then its condition is not found in the conditions list.

Here I propose a solution to this problem: when registering condition block, I check if there is key formatting function and use it, if it was not already used. It's not very elegant but works :D