### PR TITLE
Add example to Resource::DSL for has_many relationships

### DIFF
--- a/lib/jsonapi/serializable/resource/dsl.rb
+++ b/lib/jsonapi/serializable/resource/dsl.rb
@@ -150,6 +150,16 @@ module JSONAPI
         #       { author_online: @object.author.online? }
         #     end
         #   end
+        #
+        # @example
+        #   relationship :books do
+        #     data do
+        #       @object.books
+        #     end
+        #     linkage do
+        #       @object.books.map { |book| { id: book.id.to_s, type: 'books', name: book.name } }
+        #     end
+        #   end
         def relationship(name, options = {}, &block)
           rel_block = proc do
             data { @object.public_send(name) }


### PR DESCRIPTION
Increase documentation for Resource::DSL including one example for `has_many` relationships and how to use `linkage`